### PR TITLE
Fix the COPYING file to be pure MIT

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,10 +1,4 @@
-Copyright © 2006-2009 Simon Thum
-Copyright © 2008-2012 Kristian Høgsberg
-Copyright © 2010-2012 Intel Corporation
-Copyright © 2010-2011 Benjamin Franzke
-Copyright © 2011-2012 Collabora, Ltd.
-Copyright © 2013-2014 Jonas Ådahl
-Copyright © 2013-2015 Red Hat, Inc.
+Copyright © 2024 Red Hat, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -24,11 +18,3 @@ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-libinput ships a copy of the GPL-licensed Linux kernel's linux/input.h
-header file. [1] This does not make libinput GPL.
-This copy is provided to provide consistent behavior regardless which kernel
-version libinput is compiled against. The header is used during compilation
-only, libinput does not link against GPL libraries.
-
-[1] https://gitlab.freedesktop.org/libinput/libinput/blob/main/include/linux/input.h


### PR DESCRIPTION
This was obviously copied from libinput so let's trim it to what's correct for this repo.