### PR TITLE
Improve the report printing by shortening repeats

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -360,6 +360,13 @@ fn usage_to_str(u: &Usage) -> String {
     let hutstr: String =
         match hut::Usage::new_from_page_and_id(u16::from(u.usage_page), u16::from(u.usage_id)) {
             Err(_) => "<unknown>".into(),
+            Ok(hut::Usage::VendorDefinedPage { vendor_page, usage }) => {
+                format!(
+                    "Vendor Defined Usage {:04x} / {:04x}",
+                    u16::from(vendor_page),
+                    u16::from(&usage)
+                )
+            }
             Ok(u) => format!("{} / {}", hut::UsagePage::from(&u), u),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,12 +407,17 @@ fn print_report_summary(stream: &mut impl Write, r: &impl Report, opts: &Options
                     u16::from(v.usage.usage_id),
                     hutstr
                 );
+                let max = match i32::from(v.logical_maximum) {
+                    m @ -1 => format!("0x{m:x}"),
+                    m @ 0x7fffffff => format!("0x{m:x}"),
+                    m => format!("{m}"),
+                };
                 cprint!(
                     stream,
                     Styles::None,
                     "Logical Range: {:5}..={:<5} | ",
                     i32::from(v.logical_minimum),
-                    i32::from(v.logical_maximum)
+                    max,
                 );
                 if let (Some(min), Some(max)) = (v.physical_minimum, v.physical_maximum) {
                     cprint!(
@@ -476,12 +481,17 @@ fn print_report_summary(stream: &mut impl Write, r: &impl Report, opts: &Options
                         "... use --full to see all usages"
                     );
                 }
+                let max = match i32::from(a.logical_maximum) {
+                    m @ -1 => format!("0x{m:x}"),
+                    m @ 0x7fffffff => format!("0x{m:x}"),
+                    m => format!("{m}"),
+                };
                 cprint!(
                     stream,
                     Styles::None,
                     "| Logical Range: {:5}..={:<5} | ",
                     i32::from(a.logical_minimum),
-                    i32::from(a.logical_maximum)
+                    max,
                 );
                 if let (Some(min), Some(max)) = (a.physical_minimum, a.physical_maximum) {
                     cprint!(


### PR DESCRIPTION
This refactors the report printing so we can put limits on things, in particular: a device with 3 or more vendor reports in a row or 3 or more identical fields in a row will now shorten these.

My Wacom Intuos Pro hid-recorder goes from 6235 lines to 844 lines which is a lot more manageable with puny eyes. Example for repeated vendor usages:

```
# ------- Input Report -------
# Report ID: 33
#    Report size: 352 bits
#  | Bits:   8..=15  | Usage: ff00/0054: Vendor Defined Usage ff00 / 0054            | Logical Range:     0..=255
#  | Bits:  16..=23  | Usage: ff00/0051: Vendor Defined Usage ff00 / 0051            | Logical Range:     0..=255
#  | Bit:   24       | Usage: ff00/0042: Vendor Defined Usage ff00 / 0042            | Logical Range:     0..=1
#  | Bits:  25..=31  | ######### Padding
#  | Bits:  32..=47  | Usage: ff00/0130: Vendor Defined Usage ff00 / 0130            | Logical Range:     0..=8960  | Physical Range:     0..=22400 | Unit: SILinear: cm
#  | Bits:  48..=63  | Usage: ff00/0131: Vendor Defined Usage ff00 / 0131            | Logical Range:     0..=5920  | Physical Range:     0..=14800 | Unit: SILinear: cm
#  | Bits:  64..=71  | Usage: ff00/0048: Vendor Defined Usage ff00 / 0048            | Logical Range:     0..=41    | Physical Range:     0..=2238  | Unit: SILinear: cm
#  |                 | Total of 6 vendor usages, ... use --full to see all
```
and for repeated usages:

```
#  | Bits:   8..=15  | Usage: ff0d/0001: Wacom / Wacom Digitizer                     | Logical Range:     0..=255   | Physical Range:     0..=359
#  | Bits:  16..=23  | Usage: ff0d/0001: Wacom / Wacom Digitizer                     | Logical Range:     0..=255   | Physical Range:     0..=359
#  | Bits:  24..=31  | Usage: ff0d/0001: Wacom / Wacom Digitizer                     | Logical Range:     0..=255   | Physical Range:     0..=359
#  | Bits:  32..=39  | Usage: ff0d/0001: Wacom / Wacom Digitizer                     | Logical Range:     0..=255   | Physical Range:     0..=359
#  |                 | Total of 511 repeated usages, ... use --full to see all
```


cc @bentiss for awareness