### PR TITLE
Convert the description of the report descriptor into a C-compatible one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ nix = { version = "0.28.0", features = ["poll"] }
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
 chrono = "0.4.38"
 hidreport = "0.4.0"
-hut = "0.2.0"
+hut = { git = "https://github.com/bentiss/hut.git", rev = "41a82286821f5ba697d54ddb0888162207c9daa3" }
 human-sort = "0.2.2"


### PR DESCRIPTION
The idea is to make use of https://gitlab.freedesktop.org/libevdev/udev-hid-bpf/-/blob/main/src/bpf/hid_report_helpers.h
The description doesn't lose much of its value from a human perspective but can now be parsed by a C compiler if we include that file from above.

It's probably not perfect, but it seems to give correct results for the device I tested it with.

A second pair of eyes would be appreciated :)

Marking as draft because we need https://github.com/hidutils/hut/pull/9 merged first and Cargo.toml amended