### PR TITLE
CI: prebuild a hid-recorder binary and attach that to releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: test suite
 on: [push, pull_request]
 
 jobs:
-  test:
+  build-and-test:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
@@ -17,3 +17,33 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt --check
+
+  release-build:
+     name: cargo build --release
+     runs-on: ubuntu-22.04
+     needs: [build-and-test]
+     steps:
+       - uses: actions/checkout@v4
+       - uses: dtolnay/rust-toolchain@stable
+       - run: cargo build --release
+       - run: cp target/release/hid-recorder .
+       - uses: actions/upload-artifact@v4
+         with:
+           name: hid-recorder
+           path: |
+             hid-recorder
+
+  create-release:
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [release-build]
+    permissions:
+      contents: write
+    steps:
+      - uses: dawidd6/action-download-artifact@v6
+        with:
+          name: hid-recorder
+          skip_unpack: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: hid-recorder.zip

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ This is a Rust reimplementation of hid-recorder from
 
 # Installation
 
+A pre-built binary is available for our
+[releases](https://github.com/hidutils/hid-recorder/releases). Simply download the
+`hid-recorder.zip`, unpack it and you are good to go:
+```
+$ unzip hid-recorder.zip
+$ chmod +x hid-recorder
+$ sudo ./hid-recorder
+```
+
+## Installation with `cargo`
+
 The easiest is to install with cargo:
 
 ```


### PR DESCRIPTION
cc @bentiss 


~~Leaving this as draft until I've double-checked https://github.com/whot/huion-switcher/pull/11 works (which is effectively the same code).~~


Closes #29 