### PR TITLE
Split into multiple backends and add support for hid/libinput recording parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hidreport = "0.4.0"
 hut = "0.2.0"
 human-sort = "0.2.2"
 libbpf-rs = "0.23"
+yaml-rust2 = "0.8.1"
 
 [build-dependencies]
 libbpf-cargo = "0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hut = "0.2.0"
 human-sort = "0.2.2"
 libbpf-rs = "0.23"
 yaml-rust2 = "0.8.1"
+hex = "0.4.3"
 
 [build-dependencies]
 libbpf-cargo = "0.23"

--- a/src/hidraw.rs
+++ b/src/hidraw.rs
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::{bail, Result};
+use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
+use owo_colors::{OwoColorize, Stream::Stdout};
+use std::cell::OnceCell;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::os::fd::{AsFd, AsRawFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::{
+    find_sysfs_path, parse_uevent, print_bpf_input_report_data, print_current_time,
+    print_input_report_data, print_input_report_description, Backend, BpfOption, Outfile,
+    ReportDescriptor, Styles,
+};
+
+use libbpf_rs::libbpf_sys;
+use libbpf_rs::skel::OpenSkel as _;
+use libbpf_rs::skel::SkelBuilder as _;
+
+mod hidrecord {
+    include!(env!("SKELFILE"));
+}
+mod hidrecord_tracing {
+    include!(env!("SKELFILE_TRACING"));
+}
+
+use hidrecord::*;
+use hidrecord_tracing::*;
+
+const PACKET_SIZE: usize = 64;
+
+// A Rust version of hid_recorder_event in hidrecord.bpf.c
+// struct hid_recorder_event {
+// 	__u8 length;
+// 	__u8 data[64];
+// };
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct hid_recorder_event {
+    packet_count: u8,
+    packet_number: u8,
+    length: u8,
+    data: [u8; PACKET_SIZE],
+}
+
+// A Rust version of attach_prog_args in hidrecord_tracing.bpf.c
+// struct attach_prog_args {
+// 	int prog_fd;
+// 	unsigned int hid;
+// 	int retval;
+// };
+#[allow(non_camel_case_types)]
+#[repr(C)]
+struct attach_prog_args {
+    prog_fd: i32,
+    hid: u32,
+    retval: i32,
+}
+
+#[derive(Debug)]
+pub enum BpfError {
+    LibBPFError { error: libbpf_rs::Error },
+    OsError { errno: u32 },
+}
+
+impl std::error::Error for BpfError {}
+
+impl std::fmt::Display for BpfError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BpfError::LibBPFError { error } => write!(f, "{error}"),
+            BpfError::OsError { errno } => {
+                write!(f, "{}", libbpf_rs::Error::from_raw_os_error(*errno as i32))
+            }
+        }
+    }
+}
+
+impl From<libbpf_rs::Error> for BpfError {
+    fn from(e: libbpf_rs::Error) -> BpfError {
+        BpfError::LibBPFError { error: e }
+    }
+}
+
+pub struct HidrawBackend {
+    name: String,
+    bustype: u32,
+    vid: u32,
+    pid: u32,
+    rdesc: Vec<u8>,
+    device_path: Option<PathBuf>,
+}
+
+impl HidrawBackend {
+    fn read_events_loop(
+        &self,
+        path: &Path,
+        rdesc: &ReportDescriptor,
+        map_ringbuf: Option<&libbpf_rs::Map>,
+    ) -> Result<()> {
+        let mut f = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(path)?;
+
+        let timeout = PollTimeout::try_from(1000).unwrap();
+        let start_time: OnceCell<Instant> = OnceCell::new();
+        let mut last_timestamp: Option<Instant> = None;
+        let mut data = [0; 1024];
+        let mut bpf_vec = Vec::new();
+
+        let ringbuf = map_ringbuf.map(|map_ringbuf| {
+            let mut builder = libbpf_rs::RingBufferBuilder::new();
+            builder
+                .add(map_ringbuf, |data| {
+                    bpf_event_handler(data, &mut bpf_vec, &start_time)
+                })
+                .unwrap();
+            builder.build().unwrap()
+        });
+
+        loop {
+            let mut pollfds = vec![PollFd::new(f.as_fd(), PollFlags::POLLIN)];
+            if let Some(ref ringbuf) = ringbuf {
+                let ringbuf_fd = unsafe {
+                    std::os::fd::BorrowedFd::borrow_raw(ringbuf.epoll_fd() as std::os::fd::RawFd)
+                };
+                pollfds.push(PollFd::new(ringbuf_fd, PollFlags::POLLIN));
+            }
+
+            if poll(&mut pollfds, timeout)? > 0 {
+                let has_events: Vec<bool> = pollfds
+                    .iter()
+                    .map(|fd| fd.revents())
+                    .map(|revents| revents.map_or(false, |flag| flag.intersects(PollFlags::POLLIN)))
+                    .collect();
+
+                if has_events[0] {
+                    match f.read(&mut data) {
+                        Ok(_nbytes) => {
+                            last_timestamp = print_current_time(last_timestamp);
+                            let _ = start_time.get_or_init(|| last_timestamp.unwrap());
+                            print_input_report_description(&data, rdesc)?;
+
+                            let elapsed = start_time.get().unwrap().elapsed();
+                            // This prints the B: 123 00 01 02 ... data line via the callback
+                            if let Some(ref ringbuf) = ringbuf {
+                                let _ = ringbuf.consume();
+                            }
+
+                            print_input_report_data(&data, rdesc, &elapsed)?;
+                        }
+                        Err(e) => {
+                            if e.kind() != std::io::ErrorKind::WouldBlock {
+                                bail!(e);
+                            }
+                        }
+                    };
+                }
+                if *has_events.get(1).unwrap_or(&false) {
+                    if let Some(ref ringbuf) = ringbuf {
+                        last_timestamp = print_current_time(last_timestamp);
+                        let _ = start_time.get_or_init(|| last_timestamp.unwrap());
+                        let _ = ringbuf.consume();
+                    }
+                }
+            } else if last_timestamp.is_some() {
+                print_current_time(last_timestamp);
+            }
+        }
+    }
+}
+
+impl TryFrom<&Path> for HidrawBackend {
+    type Error = anyhow::Error;
+
+    fn try_from(path: &Path) -> Result<Self> {
+        if ["/dev", "/sys"]
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+        {
+            let sysfs = find_sysfs_path(path)?;
+            let rdesc_path = sysfs.join("report_descriptor");
+            if !rdesc_path.exists() {
+                bail!("Unable to find report descriptor at {rdesc_path:?}");
+            }
+
+            let (name, ids) = parse_uevent(&sysfs)?;
+            let (bustype, vid, pid) = ids;
+
+            let bytes = std::fs::read(&rdesc_path)?;
+            if bytes.is_empty() {
+                bail!("Empty report descriptor");
+            }
+
+            let device_path = if path.starts_with("/dev") {
+                Some(PathBuf::from(path))
+            } else {
+                None
+            };
+
+            Ok(HidrawBackend {
+                name,
+                bustype,
+                vid,
+                pid,
+                rdesc: bytes,
+                device_path,
+            })
+        } else {
+            bail!("Not a syfs file or hidraw node");
+        }
+    }
+}
+
+impl Backend for HidrawBackend {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn bustype(&self) -> u32 {
+        self.bustype
+    }
+
+    fn vid(&self) -> u32 {
+        self.vid
+    }
+
+    fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    fn rdesc(&self) -> &[u8] {
+        &self.rdesc
+    }
+
+    fn read_events(&self, use_bpf: BpfOption, rdesc: &ReportDescriptor) -> Result<()> {
+        if self.device_path.is_none() {
+            return Ok(());
+        }
+        let path = self.device_path.as_ref().unwrap();
+        match preload_bpf_tracer(use_bpf, &path)? {
+            HidBpfSkel::None => self.read_events_loop(&path, rdesc, None)?,
+            HidBpfSkel::StructOps(skel) => {
+                let maps = skel.maps();
+                // We need to keep _link around or the program gets immediately removed
+                let _link = maps.hid_record().attach_struct_ops()?;
+                self.read_events_loop(&path, rdesc, Some(maps.events()))?
+            }
+            HidBpfSkel::Tracing(skel, hid_id) => {
+                let attach_args = attach_prog_args {
+                    prog_fd: skel.progs().hid_record_event().as_fd().as_raw_fd(),
+                    hid: hid_id,
+                    retval: -1,
+                };
+
+                let _link =
+                    run_syscall_prog_attach(skel.progs().attach_prog(), attach_args).unwrap();
+                self.read_events_loop(&path, rdesc, Some(skel.maps().events()))?
+            }
+        }
+        Ok(())
+    }
+}
+
+fn bpf_event_handler(
+    data: &[u8],
+    buffer: &mut Vec<u8>,
+    start_time: &OnceCell<Instant>,
+) -> ::std::os::raw::c_int {
+    if data.len() != std::mem::size_of::<hid_recorder_event>() {
+        eprintln!(
+            "Invalid size {} != {}",
+            data.len(),
+            std::mem::size_of::<hid_recorder_event>()
+        );
+        return 1;
+    }
+
+    let event = unsafe { &*(data.as_ptr() as *const hid_recorder_event) };
+
+    if event.length == 0 {
+        return 1;
+    }
+
+    let elapsed = start_time.get().unwrap().elapsed();
+
+    let size = if event.packet_number == event.packet_count - 1 {
+        event.length as usize - event.packet_number as usize * PACKET_SIZE
+    } else {
+        PACKET_SIZE
+    };
+
+    if event.packet_number == 0 {
+        buffer.clear();
+    }
+
+    buffer.extend_from_slice(&event.data[..size]);
+
+    if event.packet_number == event.packet_count - 1 {
+        print_bpf_input_report_data(&buffer, &elapsed);
+    }
+    0
+}
+
+enum HidBpfSkel {
+    None,
+    StructOps(Box<HidrecordSkel<'static>>),
+    Tracing(Box<HidrecordTracingSkel<'static>>, u32),
+}
+
+fn print_to_log(level: libbpf_rs::PrintLevel, msg: String) {
+    /* we strip out the 3 following lines that happen when the kernel
+     * doesn't support HID-BPF struct_ops
+     */
+    let ignore_msgs = [
+        "struct bpf_struct_ops_hid_bpf_ops is not found in kernel BTF",
+        "failed to load object 'hidrecord_bpf'",
+        "failed to load BPF skeleton 'hidrecord_bpf': -2",
+    ];
+    if ignore_msgs.iter().any(|ignore| msg.contains(ignore)) {
+        return;
+    }
+    match level {
+        libbpf_rs::PrintLevel::Info => cprintln!(Styles::Bpf, "{}", msg.trim()),
+        libbpf_rs::PrintLevel::Warn => cprintln!(Styles::Note, "{}", msg.trim()),
+        _ => (),
+    }
+}
+
+fn preload_bpf_tracer(use_bpf: BpfOption, path: &Path) -> Result<HidBpfSkel> {
+    let sysfs = find_sysfs_path(path)?.canonicalize()?;
+    let hid_id = u32::from_str_radix(
+        sysfs
+            .extension()
+            .unwrap()
+            .to_str()
+            .expect("not a hex value"),
+        16,
+    )
+    .unwrap();
+
+    let sysfs_name = sysfs
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .replace([':', '.'], "_");
+
+    let bpffs = PathBuf::from("/sys/fs/bpf/hid/").join(sysfs_name);
+
+    let enable_bpf = match use_bpf {
+        BpfOption::Never => false,
+        BpfOption::Always => true,
+        BpfOption::Auto => bpffs.exists(),
+    };
+
+    if !enable_bpf {
+        return Ok(HidBpfSkel::None);
+    }
+
+    libbpf_rs::set_print(Some((libbpf_rs::PrintLevel::Info, print_to_log)));
+
+    let skel_builder = HidrecordSkelBuilder::default();
+    let mut open_skel = skel_builder.open().unwrap();
+    let hid_record_update = open_skel.struct_ops.hid_record_mut();
+    hid_record_update.hid_id = hid_id as i32;
+
+    if let Ok(skel) = open_skel.load() {
+        return Ok(HidBpfSkel::StructOps(Box::new(skel)));
+    }
+
+    let skel_builder = HidrecordTracingSkelBuilder::default();
+    let skel = skel_builder.open()?.load()?;
+    Ok(HidBpfSkel::Tracing(Box::new(skel), hid_id))
+}
+
+fn run_syscall_prog_generic<T>(prog: &libbpf_rs::Program, data: T) -> Result<T, BpfError> {
+    let fd = prog.as_fd().as_raw_fd();
+    let data_ptr: *const libc::c_void = &data as *const _ as *const libc::c_void;
+    let mut run_opts = libbpf_sys::bpf_test_run_opts {
+        sz: std::mem::size_of::<libbpf_sys::bpf_test_run_opts>()
+            .try_into()
+            .unwrap(),
+        ctx_in: data_ptr,
+        ctx_size_in: std::mem::size_of::<T>() as u32,
+        ..Default::default()
+    };
+
+    let run_opts_ptr: *mut libbpf_sys::bpf_test_run_opts = &mut run_opts;
+
+    match unsafe { libbpf_sys::bpf_prog_test_run_opts(fd, run_opts_ptr) } {
+        0 => Ok(data),
+        e => Err(BpfError::OsError { errno: -e as u32 }),
+    }
+}
+
+fn run_syscall_prog_attach(
+    prog: &libbpf_rs::Program,
+    attach_args: attach_prog_args,
+) -> Result<i32, BpfError> {
+    let args = run_syscall_prog_generic(prog, attach_args)?;
+    if args.retval < 0 {
+        Err(BpfError::OsError {
+            errno: -args.retval as u32,
+        })
+    } else {
+        Ok(args.retval)
+    }
+}

--- a/src/hidraw.rs
+++ b/src/hidraw.rs
@@ -336,10 +336,10 @@ fn print_to_log(level: libbpf_rs::PrintLevel, msg: String) {
     }
     match level {
         libbpf_rs::PrintLevel::Info => {
-            Outfile::new().writeln(&Styles::Bpf, format!("{}", msg.trim()).as_str())
+            Outfile::new().writeln(&Styles::Bpf, format!("# {}", msg.trim()).as_str())
         }
         libbpf_rs::PrintLevel::Warn => {
-            Outfile::new().writeln(&Styles::Note, format!("{}", msg.trim()).as_str())
+            Outfile::new().writeln(&Styles::Note, format!("# {}", msg.trim()).as_str())
         }
         _ => (),
     }

--- a/src/hidrecording.rs
+++ b/src/hidrecording.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::{bail, Context, Result};
+use std::io::BufRead;
+use std::path::Path;
+use std::time::Duration;
+
+use crate::{
+    print_input_report_data, print_input_report_description, Backend, BpfOption, ReportDescriptor,
+};
+
+// FIXME: add a enum to differ between hid events and bpf events
+
+struct HidRecorderEvent {
+    usecs: u64,
+    bytes: Vec<u8>,
+}
+
+pub struct HidRecorderBackend {
+    name: String,
+    bustype: u16,
+    vid: u16,
+    pid: u16,
+    rdesc: Vec<u8>,
+    events: Vec<HidRecorderEvent>,
+}
+
+impl HidRecorderBackend {}
+
+/// Decode a length-prefixed string of bytes, e.g.
+/// 4 00 01 02 03 04
+/// ^ ^------------^
+/// |      |
+/// |      + bytes in hex
+/// +-- length in bytes, decimal
+fn decode_length_prefixed_data(str: &str) -> Result<(usize, Vec<u8>)> {
+    let Some((length, rest)) = str.split_once(' ') else {
+        bail!("Invalid format, expected <length> [byte, byte, ...]");
+    };
+    let length = length.parse::<usize>()?;
+    let bytes = hex::decode(rest.replace(' ', ""))?;
+
+    if length != bytes.len() {
+        bail!("Invalid data length: {} expected {}", bytes.len(), length);
+    }
+
+    Ok((length, bytes))
+}
+
+impl TryFrom<&Path> for HidRecorderBackend {
+    type Error = anyhow::Error;
+
+    fn try_from(path: &Path) -> Result<Self> {
+        let f = std::fs::File::open(path)?;
+        let lines = std::io::BufReader::new(f)
+            .lines()
+            .map_while(Result::ok)
+            .map(|l| String::from(l.trim()));
+
+        let mut name = None;
+        let mut bustype: Option<u16> = None;
+        let mut vid: Option<u16> = None;
+        let mut pid: Option<u16> = None;
+        let mut rdesc: Option<Vec<u8>> = None;
+        let mut events: Vec<HidRecorderEvent> = Vec::new();
+
+        for line in lines {
+            if line.is_empty() || line.starts_with("#") {
+                continue;
+            }
+            match line.split_once(' ') {
+                Some(("N:", rest)) => name = Some(String::from(rest)),
+                Some(("I:", rest)) => {
+                    let v = rest
+                        .split(' ')
+                        .map(|s| u16::from_str_radix(s, 16))
+                        .collect::<Result<Vec<u16>, _>>()?;
+                    bustype = Some(*v.get(0).context("Missing bustype")?);
+                    vid = Some(*v.get(1).context("Missing vid")?);
+                    pid = Some(*v.get(2).context("Missing pid")?);
+                }
+                Some(("R:", rest)) => {
+                    rdesc = Some(
+                        decode_length_prefixed_data(rest)
+                            .context("Invalid report descriptor")?
+                            .1,
+                    );
+                }
+                Some(("E:", rest)) => {
+                    let (timestamp, rest) = rest.split_once(' ').context("Missing timestamp")?;
+                    let (secs, usecs) = timestamp
+                        .split_once('.')
+                        .context("Invalid timestamp format")?;
+                    let secs = secs
+                        .parse::<u64>()
+                        .context(format!("Invalid timestamp string {secs}"))?;
+                    let usecs = usecs
+                        .parse::<u64>()
+                        .context(format!("Invalid timestamp string {usecs}"))?;
+                    let bytes = decode_length_prefixed_data(rest)
+                        .context("Invalid bytes")?
+                        .1;
+                    events.push(HidRecorderEvent {
+                        usecs: secs * 1_000_000 + usecs,
+                        bytes,
+                    })
+                }
+                // ignore unknown prefixes
+                _ => {}
+            };
+        }
+
+        Ok(HidRecorderBackend {
+            name: name.context("Missing name")?,
+            bustype: bustype.context("Missing bustype")?,
+            vid: vid.context("Missing vid")?,
+            pid: pid.context("Missing pid")?,
+            rdesc: rdesc.context("Missing rdesc")?,
+            events,
+        })
+    }
+}
+
+impl Backend for HidRecorderBackend {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn bustype(&self) -> u32 {
+        self.bustype as u32
+    }
+
+    fn vid(&self) -> u32 {
+        self.vid as u32
+    }
+
+    fn pid(&self) -> u32 {
+        self.pid as u32
+    }
+
+    fn rdesc(&self) -> &[u8] {
+        &self.rdesc
+    }
+
+    fn read_events(&self, _use_bpf: BpfOption, rdesc: &ReportDescriptor) -> Result<()> {
+        for e in self.events.iter() {
+            let elapsed = Duration::from_micros(e.usecs);
+            print_input_report_description(&e.bytes, rdesc)?;
+            print_input_report_data(&e.bytes, rdesc, &elapsed)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/libinput.rs
+++ b/src/libinput.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+//
+
+use anyhow::{bail, Context, Result};
+use std::io::Read;
+use std::path::Path;
+use yaml_rust2::{Yaml, YamlLoader};
+
+use crate::{Backend, BpfOption, ReportDescriptor};
+
+#[derive(Debug)]
+pub struct LibinputRecordingBackend {
+    name: String,
+    bustype: u32,
+    vid: u32,
+    pid: u32,
+    rdesc: Vec<u8>,
+}
+
+impl TryFrom<&Path> for LibinputRecordingBackend {
+    type Error = anyhow::Error;
+
+    fn try_from(path: &Path) -> Result<Self> {
+        let mut file = std::fs::File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        let yml = YamlLoader::load_from_str(&contents)?;
+        let yml = &yml[0]; // we don't know any multi-document yaml sources
+        let root = yml.as_hash().context("Not a libinput recording")?;
+        if !root.contains_key(&Yaml::String("libinput".into())) {
+            bail!("Not a libinput recording");
+        }
+        let devices = root
+            .get(&Yaml::String("devices".into()))
+            .context("Malformed libinput recording - missing devices")?;
+        // We quietly pick the first device only
+        let device = devices
+            .as_vec()
+            .context("Malformed libinput recording - devices isn't a list")?
+            .get(0)
+            .context("Malformed libinput recording - no devices")?
+            .as_hash()
+            .context("Malformed libinput recording - device not an object")?;
+        let hid: &Vec<Yaml> = device
+            .get(&Yaml::String("hid".into()))
+            .context("Not a libinput recording - hid element missing")?
+            .as_vec()
+            .context("Malformed libinput recording - hid not an array")?;
+        let bytes = hid
+            .iter()
+            .map(|entry| {
+                entry
+                    .as_i64()
+                    .and_then(|i| u8::try_from(i).ok())
+                    .context("Malformed libinput recording - not a i8")
+            })
+            .collect::<Result<Vec<u8>, anyhow::Error>>()?;
+
+        let evdev = device
+            .get(&Yaml::String("evdev".into()))
+            .context("Malformed libinput recording - evdev is missing")?
+            .as_hash()
+            .context("Malformed libinput recording - evdev is not an object")?;
+        let name = evdev
+            .get(&Yaml::String("name".into()))
+            .context("Malformed libinput recording - name is missing")?
+            .as_str()
+            .context("Malformed libinput recording - name is not a string")?;
+        let ids = evdev
+            .get(&Yaml::String("id".into()))
+            .context("Malformed libinput recording - ids missing")?
+            .as_vec()
+            .context("Malformed libinput recording - ids not an array")?
+            .iter()
+            .map(|id| {
+                id.as_i64()
+                    .and_then(|i| u32::try_from(i).ok())
+                    .context("Malformed libinput recording - ids not u16")
+            })
+            .collect::<Result<Vec<u32>, anyhow::Error>>()?;
+
+        let bustype = *ids
+            .get(0)
+            .context("Malformed libinput recording - missing bustype")?;
+        let vid = *ids
+            .get(1)
+            .context("Malformed libinput recording - missing vid")?;
+        let pid = *ids
+            .get(2)
+            .context("Malformed libinput recording - missing pid")?;
+
+        Ok(LibinputRecordingBackend {
+            name: String::from(name),
+            bustype,
+            vid,
+            pid,
+            rdesc: bytes,
+        })
+    }
+}
+
+impl Backend for LibinputRecordingBackend {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn bustype(&self) -> u32 {
+        self.bustype
+    }
+
+    fn vid(&self) -> u32 {
+        self.vid
+    }
+
+    fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    fn rdesc(&self) -> &[u8] {
+        &self.rdesc
+    }
+
+    fn read_events(&self, _use_bpf: BpfOption, _rdesc: &ReportDescriptor) -> Result<()> {
+        // libinput recordings very rarely have HID events so let's not bother
+        // until we need this
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,10 @@
 
 use anyhow::{bail, Context, Result};
 use clap::{ColorChoice, Parser};
-use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
 use owo_colors::{OwoColorize, Rgb, Stream::Stdout, Style};
-use std::cell::OnceCell;
 use std::collections::HashSet;
-use std::fs::OpenOptions;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::ops::Deref;
-use std::os::fd::{AsFd, AsRawFd};
-use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::OnceLock;
@@ -25,34 +20,17 @@ use hidreport::hid::{
 };
 use hidreport::*;
 
-use libbpf_rs::libbpf_sys;
-use libbpf_rs::skel::OpenSkel as _;
-use libbpf_rs::skel::SkelBuilder as _;
-
-mod hidrecord {
-    include!(env!("SKELFILE"));
-}
-mod hidrecord_tracing {
-    include!(env!("SKELFILE_TRACING"));
-}
-
-use hidrecord::*;
-use hidrecord_tracing::*;
-
-mod hidrecording;
-mod libinput;
-
 static mut OUTFILE: OnceLock<
     std::sync::Mutex<std::cell::RefCell<std::io::LineWriter<std::fs::File>>>,
 > = OnceLock::new();
 
-enum Outfile {
+pub enum Outfile {
     Stdout,
     File(&'static mut std::sync::Mutex<std::cell::RefCell<std::io::LineWriter<std::fs::File>>>),
 }
 
 impl Outfile {
-    fn new() -> Self {
+    pub fn new() -> Self {
         unsafe {
             match OUTFILE.get_mut() {
                 None => Outfile::Stdout,
@@ -114,217 +92,6 @@ trait Backend {
     fn pid(&self) -> u32;
     fn rdesc(&self) -> &[u8];
     fn read_events(&self, use_bpf: BpfOption, rdesc: &ReportDescriptor) -> Result<()>;
-}
-
-struct HidrawBackend {
-    name: String,
-    bustype: u32,
-    vid: u32,
-    pid: u32,
-    rdesc: Vec<u8>,
-    device_path: Option<PathBuf>,
-}
-
-impl HidrawBackend {
-    fn read_events_loop(
-        &self,
-        path: &Path,
-        rdesc: &ReportDescriptor,
-        map_ringbuf: Option<&libbpf_rs::Map>,
-    ) -> Result<()> {
-        let mut f = OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NONBLOCK)
-            .open(path)?;
-
-        let timeout = PollTimeout::try_from(1000).unwrap();
-        let start_time: OnceCell<Instant> = OnceCell::new();
-        let mut last_timestamp: Option<Instant> = None;
-        let mut data = [0; 1024];
-        let mut bpf_vec = Vec::new();
-
-        let ringbuf = map_ringbuf.map(|map_ringbuf| {
-            let mut builder = libbpf_rs::RingBufferBuilder::new();
-            builder
-                .add(map_ringbuf, |data| {
-                    bpf_event_handler(data, &mut bpf_vec, &start_time)
-                })
-                .unwrap();
-            builder.build().unwrap()
-        });
-
-        loop {
-            let mut pollfds = vec![PollFd::new(f.as_fd(), PollFlags::POLLIN)];
-            if let Some(ref ringbuf) = ringbuf {
-                let ringbuf_fd = unsafe {
-                    std::os::fd::BorrowedFd::borrow_raw(ringbuf.epoll_fd() as std::os::fd::RawFd)
-                };
-                pollfds.push(PollFd::new(ringbuf_fd, PollFlags::POLLIN));
-            }
-
-            if poll(&mut pollfds, timeout)? > 0 {
-                let has_events: Vec<bool> = pollfds
-                    .iter()
-                    .map(|fd| fd.revents())
-                    .map(|revents| revents.map_or(false, |flag| flag.intersects(PollFlags::POLLIN)))
-                    .collect();
-
-                if has_events[0] {
-                    match f.read(&mut data) {
-                        Ok(_nbytes) => {
-                            last_timestamp = print_current_time(last_timestamp);
-                            let _ = start_time.get_or_init(|| last_timestamp.unwrap());
-                            print_input_report_description(&data, rdesc)?;
-
-                            let elapsed = start_time.get().unwrap().elapsed();
-                            // This prints the B: 123 00 01 02 ... data line via the callback
-                            if let Some(ref ringbuf) = ringbuf {
-                                let _ = ringbuf.consume();
-                            }
-
-                            print_input_report_data(&data, rdesc, &elapsed)?;
-                        }
-                        Err(e) => {
-                            if e.kind() != std::io::ErrorKind::WouldBlock {
-                                bail!(e);
-                            }
-                        }
-                    };
-                }
-                if *has_events.get(1).unwrap_or(&false) {
-                    if let Some(ref ringbuf) = ringbuf {
-                        last_timestamp = print_current_time(last_timestamp);
-                        let _ = start_time.get_or_init(|| last_timestamp.unwrap());
-                        let _ = ringbuf.consume();
-                    }
-                }
-            } else if last_timestamp.is_some() {
-                print_current_time(last_timestamp);
-            }
-        }
-    }
-}
-
-impl TryFrom<&Path> for HidrawBackend {
-    type Error = anyhow::Error;
-
-    fn try_from(path: &Path) -> Result<Self> {
-        if ["/dev", "/sys"]
-            .iter()
-            .any(|prefix| path.starts_with(prefix))
-        {
-            let sysfs = find_sysfs_path(path)?;
-            let rdesc_path = sysfs.join("report_descriptor");
-            if !rdesc_path.exists() {
-                bail!("Unable to find report descriptor at {rdesc_path:?}");
-            }
-
-            let (name, ids) = parse_uevent(&sysfs)?;
-            let (bustype, vid, pid) = ids;
-
-            let bytes = std::fs::read(&rdesc_path)?;
-            if bytes.is_empty() {
-                bail!("Empty report descriptor");
-            }
-
-            let device_path = if path.starts_with("/dev") {
-                Some(PathBuf::from(path))
-            } else {
-                None
-            };
-
-            Ok(HidrawBackend {
-                name,
-                bustype,
-                vid,
-                pid,
-                rdesc: bytes,
-                device_path,
-            })
-        } else {
-            bail!("Not a syfs file or hidraw node");
-        }
-    }
-}
-
-impl Backend for HidrawBackend {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn bustype(&self) -> u32 {
-        self.bustype
-    }
-
-    fn vid(&self) -> u32 {
-        self.vid
-    }
-
-    fn pid(&self) -> u32 {
-        self.pid
-    }
-
-    fn rdesc(&self) -> &[u8] {
-        &self.rdesc
-    }
-
-    fn read_events(&self, use_bpf: BpfOption, rdesc: &ReportDescriptor) -> Result<()> {
-        if self.device_path.is_none() {
-            return Ok(());
-        }
-        let path = self.device_path.as_ref().unwrap();
-        match preload_bpf_tracer(use_bpf, &path)? {
-            HidBpfSkel::None => self.read_events_loop(&path, rdesc, None)?,
-            HidBpfSkel::StructOps(skel) => {
-                let maps = skel.maps();
-                // We need to keep _link around or the program gets immediately removed
-                let _link = maps.hid_record().attach_struct_ops()?;
-                self.read_events_loop(&path, rdesc, Some(maps.events()))?
-            }
-            HidBpfSkel::Tracing(skel, hid_id) => {
-                let attach_args = attach_prog_args {
-                    prog_fd: skel.progs().hid_record_event().as_fd().as_raw_fd(),
-                    hid: hid_id,
-                    retval: -1,
-                };
-
-                let _link =
-                    run_syscall_prog_attach(skel.progs().attach_prog(), attach_args).unwrap();
-                self.read_events_loop(&path, rdesc, Some(skel.maps().events()))?
-            }
-        }
-        Ok(())
-    }
-}
-
-const PACKET_SIZE: usize = 64;
-
-// A Rust version of hid_recorder_event in hidrecord.bpf.c
-// struct hid_recorder_event {
-// 	__u8 length;
-// 	__u8 data[64];
-// };
-#[allow(non_camel_case_types)]
-#[repr(C)]
-struct hid_recorder_event {
-    packet_count: u8,
-    packet_number: u8,
-    length: u8,
-    data: [u8; PACKET_SIZE],
-}
-
-// A Rust version of attach_prog_args in hidrecord_tracing.bpf.c
-// struct attach_prog_args {
-// 	int prog_fd;
-// 	unsigned int hid;
-// 	int retval;
-// };
-#[allow(non_camel_case_types)]
-#[repr(C)]
-struct attach_prog_args {
-    prog_fd: i32,
-    hid: u32,
-    retval: i32,
 }
 
 #[derive(Default)]
@@ -395,6 +162,10 @@ macro_rules! cprint {
     }};
 }
 
+mod hidraw;
+mod hidrecording;
+mod libinput;
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Cli {
@@ -432,31 +203,6 @@ struct Options {
     full: bool,
     only_describe: bool,
     bpf: ColorChoice,
-}
-
-#[derive(Debug)]
-pub enum BpfError {
-    LibBPFError { error: libbpf_rs::Error },
-    OsError { errno: u32 },
-}
-
-impl std::error::Error for BpfError {}
-
-impl std::fmt::Display for BpfError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BpfError::LibBPFError { error } => write!(f, "{error}"),
-            BpfError::OsError { errno } => {
-                write!(f, "{}", libbpf_rs::Error::from_raw_os_error(*errno as i32))
-            }
-        }
-    }
-}
-
-impl From<libbpf_rs::Error> for BpfError {
-    fn from(e: libbpf_rs::Error) -> BpfError {
-        BpfError::LibBPFError { error: e }
-    }
 }
 
 fn fmt_main_item(item: &MainItem) -> String {
@@ -672,7 +418,7 @@ fn print_rdesc_items(bytes: &[u8]) -> Result<()> {
 }
 
 // This would be easier with udev but let's keep the dependencies relatively minimal.
-fn find_sysfs_path(path: &Path) -> Result<PathBuf> {
+pub fn find_sysfs_path(path: &Path) -> Result<PathBuf> {
     let pathstr = path.to_string_lossy();
     let sysfs: PathBuf;
     if pathstr.starts_with("/dev/hidraw") {
@@ -1049,7 +795,7 @@ fn print_report_summary(r: &impl Report, opts: &Options) {
     }
 }
 
-fn parse_uevent(sysfs: &Path) -> Result<(String, (u32, u32, u32))> {
+pub fn parse_uevent(sysfs: &Path) -> Result<(String, (u32, u32, u32))> {
     // uevent should contain
     // HID_NAME=foo bar
     // HID_ID=00003:0002135:0000123513
@@ -1276,7 +1022,7 @@ pub fn print_input_report_description(bytes: &[u8], rdesc: &ReportDescriptor) ->
     Ok(())
 }
 
-fn print_input_report_data(
+pub fn print_input_report_data(
     bytes: &[u8],
     rdesc: &ReportDescriptor,
     elapsed: &Duration,
@@ -1299,7 +1045,7 @@ fn print_input_report_data(
     Ok(())
 }
 
-fn print_bpf_input_report_data(bytes: &[u8], elapsed: &Duration) {
+pub fn print_bpf_input_report_data(bytes: &[u8], elapsed: &Duration) {
     let bytes = bytes
         .iter()
         .fold("".to_string(), |acc, b| format!("{acc}{b:02x} "));
@@ -1313,7 +1059,7 @@ fn print_bpf_input_report_data(bytes: &[u8], elapsed: &Duration) {
     );
 }
 
-fn print_current_time(last_timestamp: Option<Instant>) -> Option<Instant> {
+pub fn print_current_time(last_timestamp: Option<Instant>) -> Option<Instant> {
     let prev_timestamp = last_timestamp.unwrap_or(Instant::now());
     let elapsed = prev_timestamp.elapsed().as_secs();
     let now = chrono::prelude::Local::now();
@@ -1359,152 +1105,6 @@ fn find_device() -> Result<PathBuf> {
     Ok(path)
 }
 
-fn bpf_event_handler(
-    data: &[u8],
-    buffer: &mut Vec<u8>,
-    start_time: &OnceCell<Instant>,
-) -> ::std::os::raw::c_int {
-    if data.len() != std::mem::size_of::<hid_recorder_event>() {
-        eprintln!(
-            "Invalid size {} != {}",
-            data.len(),
-            std::mem::size_of::<hid_recorder_event>()
-        );
-        return 1;
-    }
-
-    let event = unsafe { &*(data.as_ptr() as *const hid_recorder_event) };
-
-    if event.length == 0 {
-        return 1;
-    }
-
-    let elapsed = start_time.get().unwrap().elapsed();
-
-    let size = if event.packet_number == event.packet_count - 1 {
-        event.length as usize - event.packet_number as usize * PACKET_SIZE
-    } else {
-        PACKET_SIZE
-    };
-
-    if event.packet_number == 0 {
-        buffer.clear();
-    }
-
-    buffer.extend_from_slice(&event.data[..size]);
-
-    if event.packet_number == event.packet_count - 1 {
-        print_bpf_input_report_data(&buffer, &elapsed);
-    }
-    0
-}
-
-enum HidBpfSkel {
-    None,
-    StructOps(Box<HidrecordSkel<'static>>),
-    Tracing(Box<HidrecordTracingSkel<'static>>, u32),
-}
-
-fn print_to_log(level: libbpf_rs::PrintLevel, msg: String) {
-    /* we strip out the 3 following lines that happen when the kernel
-     * doesn't support HID-BPF struct_ops
-     */
-    let ignore_msgs = [
-        "struct bpf_struct_ops_hid_bpf_ops is not found in kernel BTF",
-        "failed to load object 'hidrecord_bpf'",
-        "failed to load BPF skeleton 'hidrecord_bpf': -2",
-    ];
-    if ignore_msgs.iter().any(|ignore| msg.contains(ignore)) {
-        return;
-    }
-    match level {
-        libbpf_rs::PrintLevel::Info => cprintln!(Styles::Bpf, "{}", msg.trim()),
-        libbpf_rs::PrintLevel::Warn => cprintln!(Styles::Note, "{}", msg.trim()),
-        _ => (),
-    }
-}
-
-fn preload_bpf_tracer(use_bpf: BpfOption, path: &Path) -> Result<HidBpfSkel> {
-    let sysfs = find_sysfs_path(path)?.canonicalize()?;
-    let hid_id = u32::from_str_radix(
-        sysfs
-            .extension()
-            .unwrap()
-            .to_str()
-            .expect("not a hex value"),
-        16,
-    )
-    .unwrap();
-
-    let sysfs_name = sysfs
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .replace([':', '.'], "_");
-
-    let bpffs = PathBuf::from("/sys/fs/bpf/hid/").join(sysfs_name);
-
-    let enable_bpf = match use_bpf {
-        BpfOption::Never => false,
-        BpfOption::Always => true,
-        BpfOption::Auto => bpffs.exists(),
-    };
-
-    if !enable_bpf {
-        return Ok(HidBpfSkel::None);
-    }
-
-    libbpf_rs::set_print(Some((libbpf_rs::PrintLevel::Info, print_to_log)));
-
-    let skel_builder = HidrecordSkelBuilder::default();
-    let mut open_skel = skel_builder.open().unwrap();
-    let hid_record_update = open_skel.struct_ops.hid_record_mut();
-    hid_record_update.hid_id = hid_id as i32;
-
-    if let Ok(skel) = open_skel.load() {
-        return Ok(HidBpfSkel::StructOps(Box::new(skel)));
-    }
-
-    let skel_builder = HidrecordTracingSkelBuilder::default();
-    let skel = skel_builder.open()?.load()?;
-    Ok(HidBpfSkel::Tracing(Box::new(skel), hid_id))
-}
-
-fn run_syscall_prog_generic<T>(prog: &libbpf_rs::Program, data: T) -> Result<T, BpfError> {
-    let fd = prog.as_fd().as_raw_fd();
-    let data_ptr: *const libc::c_void = &data as *const _ as *const libc::c_void;
-    let mut run_opts = libbpf_sys::bpf_test_run_opts {
-        sz: std::mem::size_of::<libbpf_sys::bpf_test_run_opts>()
-            .try_into()
-            .unwrap(),
-        ctx_in: data_ptr,
-        ctx_size_in: std::mem::size_of::<T>() as u32,
-        ..Default::default()
-    };
-
-    let run_opts_ptr: *mut libbpf_sys::bpf_test_run_opts = &mut run_opts;
-
-    match unsafe { libbpf_sys::bpf_prog_test_run_opts(fd, run_opts_ptr) } {
-        0 => Ok(data),
-        e => Err(BpfError::OsError { errno: -e as u32 }),
-    }
-}
-
-fn run_syscall_prog_attach(
-    prog: &libbpf_rs::Program,
-    attach_args: attach_prog_args,
-) -> Result<i32, BpfError> {
-    let args = run_syscall_prog_generic(prog, attach_args)?;
-    if args.retval < 0 {
-        Err(BpfError::OsError {
-            errno: -args.retval as u32,
-        })
-    } else {
-        Ok(args.retval)
-    }
-}
-
 fn process(backend: impl Backend, opts: &Options) -> Result<()> {
     let rdesc = parse_report_descriptor(&backend, &opts)?;
     if !opts.only_describe {
@@ -1538,7 +1138,7 @@ fn hid_recorder() -> Result<()> {
         only_describe: cli.only_describe,
         bpf: cli.bpf,
     };
-    if let Ok(backend) = HidrawBackend::try_from(path.as_path()) {
+    if let Ok(backend) = hidraw::HidrawBackend::try_from(path.as_path()) {
         process(backend, &opts)
     } else if let Ok(backend) = libinput::LibinputRecordingBackend::try_from(path.as_path()) {
         process(backend, &opts)
@@ -1573,7 +1173,7 @@ mod tests {
             .filter(|name| name.starts_with("hidraw"))
             .collect();
         for hidraw in hidraws.iter().map(|h| PathBuf::from("/dev/").join(h)) {
-            let result = HidrawBackend::try_from(hidraw.as_path());
+            let result = hidraw::HidrawBackend::try_from(hidraw.as_path());
             assert!(result.is_ok());
         }
     }
@@ -1595,7 +1195,7 @@ mod tests {
             assert!(evdevs
                 .iter()
                 .map(|n| PathBuf::from("/dev/input").join(n))
-                .any(|evdev| HidrawBackend::try_from(evdev.as_path()).is_ok()));
+                .any(|evdev| hidraw::HidrawBackend::try_from(evdev.as_path()).is_ok()));
         }
     }
 
@@ -1615,7 +1215,7 @@ mod tests {
             .map(|path| {
                 (
                     path.clone(),
-                    HidrawBackend::try_from(path.as_path()).unwrap(),
+                    hidraw::HidrawBackend::try_from(path.as_path()).unwrap(),
                 )
             })
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ mod hidrecord_tracing {
 use hidrecord::*;
 use hidrecord_tracing::*;
 
+mod libinput;
+
 static mut OUTFILE: OnceLock<
     std::sync::Mutex<std::cell::RefCell<std::io::LineWriter<std::fs::File>>>,
 > = OnceLock::new();
@@ -1536,6 +1538,8 @@ fn hid_recorder() -> Result<()> {
         bpf: cli.bpf,
     };
     if let Ok(backend) = HidrawBackend::try_from(path.as_path()) {
+        process(backend, &opts)
+    } else if let Ok(backend) = libinput::LibinputRecordingBackend::try_from(path.as_path()) {
         process(backend, &opts)
     } else {
         bail!("Unrecognized file format");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1137,12 +1137,7 @@ fn print_style_prefix(style: &Styles) {
     cprint!(style, " ");
 }
 
-fn parse_input_report(
-    bytes: &[u8],
-    rdesc: &ReportDescriptor,
-    start_time: &Instant,
-    ringbuf: Option<&libbpf_rs::RingBuffer>,
-) -> Result<()> {
+fn print_input_report_description(bytes: &[u8], rdesc: &ReportDescriptor) -> Result<()> {
     let Some(report) = rdesc.find_input_report(bytes) else {
         bail!("Unable to find matching report");
     };
@@ -1192,6 +1187,18 @@ fn parse_input_report(
         }
     }
 
+    Ok(())
+}
+
+fn print_input_report_data(
+    bytes: &[u8],
+    rdesc: &ReportDescriptor,
+    start_time: &Instant,
+    ringbuf: Option<&libbpf_rs::RingBuffer>,
+) -> Result<()> {
+    let Some(report) = rdesc.find_input_report(bytes) else {
+        bail!("Unable to find matching report");
+    };
     if let Some(ringbuf) = ringbuf {
         let _ = ringbuf.consume();
     }
@@ -1286,7 +1293,8 @@ fn read_events(
                     Ok(_nbytes) => {
                         last_timestamp = print_current_time(last_timestamp);
                         let _ = start_time.get_or_init(|| last_timestamp.unwrap());
-                        parse_input_report(
+                        print_input_report_description(&data, rdesc)?;
+                        print_input_report_data(
                             &data,
                             rdesc,
                             start_time.get().unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1248,17 +1248,6 @@ fn read_events(
     rdesc: &ReportDescriptor,
     map_ringbuf: Option<&libbpf_rs::Map>,
 ) -> Result<()> {
-    cprintln!(
-        Styles::Separator,
-        "##############################################################################"
-    );
-    cprintln!(Styles::None, "# Recorded events below in format:");
-    cprintln!(
-        Styles::None,
-        "# E: <seconds>.<microseconds> <length-in-bytes> [bytes ...]",
-    );
-    cprintln!(Styles::None, "#");
-
     let mut f = OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NONBLOCK)
@@ -1523,6 +1512,16 @@ fn hid_recorder() -> Result<()> {
 
     let rdesc = parse_report_descriptor(&backend, &opts)?;
     if !cli.only_describe {
+        cprintln!(
+            Styles::Separator,
+            "##############################################################################"
+        );
+        cprintln!(Styles::None, "# Recorded events below in format:");
+        cprintln!(
+            Styles::None,
+            "# E: <seconds>.<microseconds> <length-in-bytes> [bytes ...]",
+        );
+        cprintln!(Styles::None, "#");
         backend.read_events(cli.bpf, &rdesc)?;
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1266,7 +1266,7 @@ fn read_events(
         let mut builder = libbpf_rs::RingBufferBuilder::new();
         builder
             .add(map_ringbuf, |data| {
-                event_handler(data, &mut bpf_vec, &start_time)
+                bpf_event_handler(data, &mut bpf_vec, &start_time)
             })
             .unwrap();
         builder.build().unwrap()
@@ -1351,7 +1351,7 @@ fn find_device() -> Result<PathBuf> {
     Ok(path)
 }
 
-fn event_handler(
+fn bpf_event_handler(
     data: &[u8],
     buffer: &mut Vec<u8>,
     start_time: &OnceCell<Instant>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,9 +130,10 @@ impl Outfile {
         };
 
         let indented = format!("{:indent$}{}", "", item);
+        let prefix = style.as_str();
         self.writeln(
             &style,
-            format!("# {bytes:30} // {indented:41} {offset}").as_ref(),
+            format!("# {prefix} {bytes:30} // {indented:41} {offset}").as_ref(),
         );
     }
 
@@ -154,7 +155,7 @@ impl Outfile {
             Styles::None
         };
         self.write(&Styles::None, "# ");
-        self.write(&report_style, " ");
+        self.write(&report_style, report_style.as_str());
         self.write(&Styles::None, " ");
     }
 
@@ -292,6 +293,32 @@ impl From<&Styles> for Style {
                 6 => Rgb(0xe5, 0xc4, 0x94),
                 _ => Rgb(0x66, 0xc2, 0xa5),
             }),
+        }
+    }
+}
+
+impl Styles {
+    fn as_str(&self) -> &str {
+        match self {
+            Styles::None => " ",
+            Styles::Bpf => "",
+            Styles::Data => "",
+            Styles::Note => " ",
+            Styles::InputItem => "┇",
+            Styles::OutputItem => "┊",
+            Styles::FeatureItem => "║",
+            Styles::ReportId => "┅",
+            Styles::Separator => "",
+            Styles::Timestamp => "",
+            Styles::Report { report_id } => match u8::from(report_id) % 7 {
+                1 => "░",
+                2 => "▒",
+                3 => "▓",
+                4 => "▚",
+                5 => "▞",
+                6 => "▃",
+                _ => "▘",
+            },
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ impl Outfile {
         write!(
             self,
             "{}",
-            msg.if_supports_color(Stdout, |text| text.style(style.style()))
+            msg.if_supports_color(Stdout, |text| text.style(style.into()))
         )
         .unwrap();
     }
@@ -91,7 +91,7 @@ impl Outfile {
         writeln!(
             self,
             "{}",
-            msg.if_supports_color(Stdout, |text| text.style(style.style()))
+            msg.if_supports_color(Stdout, |text| text.style(style.into()))
         )
         .unwrap();
     }
@@ -270,9 +270,9 @@ pub enum Styles {
     Bpf,
 }
 
-impl Styles {
-    fn style(&self) -> Style {
-        match self {
+impl From<&Styles> for Style {
+    fn from(styles: &Styles) -> Style {
+        match styles {
             Styles::None => Style::new(),
             Styles::Bpf => Style::new().blue(),
             Styles::Data => Style::new().red(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1213,6 +1213,20 @@ fn print_input_report_data(
     Ok(())
 }
 
+fn print_bpf_input_report_data(bytes: &[u8], elapsed: &Duration) {
+    let bytes = bytes
+        .iter()
+        .fold("".to_string(), |acc, b| format!("{acc}{b:02x} "));
+    cprintln!(
+        Styles::Bpf,
+        "B: {:06}.{:06} {} {}",
+        elapsed.as_secs(),
+        elapsed.as_micros() % 1000000,
+        bytes.len(),
+        bytes,
+    );
+}
+
 fn print_current_time(last_timestamp: Option<Instant>) -> Option<Instant> {
     let prev_timestamp = last_timestamp.unwrap_or(Instant::now());
     let elapsed = prev_timestamp.elapsed().as_secs();
@@ -1382,17 +1396,7 @@ fn bpf_event_handler(
     buffer.extend_from_slice(&event.data[..size]);
 
     if event.packet_number == event.packet_count - 1 {
-        let bytes = buffer
-            .iter()
-            .fold("".to_string(), |acc, b| format!("{acc}{b:02x} "));
-        cprintln!(
-            Styles::Bpf,
-            "B: {:06}.{:06} {} {}",
-            elapsed.as_secs(),
-            elapsed.as_micros() % 1000000,
-            buffer.len(),
-            bytes,
-        );
+        print_bpf_input_report_data(&buffer, &elapsed);
     }
     0
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod hidrecord_tracing {
 use hidrecord::*;
 use hidrecord_tracing::*;
 
+mod hidrecording;
 mod libinput;
 
 static mut OUTFILE: OnceLock<
@@ -1222,7 +1223,7 @@ fn print_style_prefix(style: &Styles) {
     cprint!(style, " ");
 }
 
-fn print_input_report_description(bytes: &[u8], rdesc: &ReportDescriptor) -> Result<()> {
+pub fn print_input_report_description(bytes: &[u8], rdesc: &ReportDescriptor) -> Result<()> {
     let Some(report) = rdesc.find_input_report(bytes) else {
         bail!("Unable to find matching report");
     };
@@ -1540,6 +1541,8 @@ fn hid_recorder() -> Result<()> {
     if let Ok(backend) = HidrawBackend::try_from(path.as_path()) {
         process(backend, &opts)
     } else if let Ok(backend) = libinput::LibinputRecordingBackend::try_from(path.as_path()) {
+        process(backend, &opts)
+    } else if let Ok(backend) = hidrecording::HidRecorderBackend::try_from(path.as_path()) {
         process(backend, &opts)
     } else {
         bail!("Unrecognized file format");


### PR DESCRIPTION
This is a bit messy and there's more future cleanup possible but meanwhile this is it:

- add a `Backend` trait that handles the actual parsing and reading of data
- move the hidraw bits into its own backend
- add backends for libinput recordings and hid recorder recordings
- move the `cprintln` bits into functions on the `Outfile` so the backends don't need to care about individual line formatting

The latter is a bit unrelated but copy/pasting the same printf statements was getting annoying.

The goal eventually is to make the `Outfile` functions color-support-aware so we can fix #39 