### PR TITLE
Silence two new default-on clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ impl Default for Outfile {
 impl Outfile {
     pub fn new() -> Self {
         unsafe {
+            #[allow(static_mut_refs)]
             match OUTFILE.get_mut() {
                 None => Outfile::Stdout,
                 Some(o) => Outfile::File(o),
@@ -76,6 +77,7 @@ impl Outfile {
         if cli.output_file != "-" {
             let out = std::fs::File::create(cli.output_file.clone()).unwrap();
             let _ = unsafe {
+                #[allow(static_mut_refs)]
                 OUTFILE.set(std::sync::Mutex::new(std::cell::RefCell::new(
                     std::io::LineWriter::new(out),
                 )))


### PR DESCRIPTION
```
error: creating a mutable reference to mutable static is discouraged
  --> hid-recorder/src/main.rs:62:19
   |
62 |             match OUTFILE.get_mut() {
   |                   ^^^^^^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
   = note: `-D static-mut-refs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(static_mut_refs)]`
error: creating a shared reference to mutable static is discouraged
  --> hid-recorder/src/main.rs:79:17
   |
79 | /                 OUTFILE.set(std::sync::Mutex::new(std::cell::RefCell::new(
80 | |                     std::io::LineWriter::new(out),
81 | |                 )))
   | |___________________^ shared reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

```

These are currently preventing pre-commit from running locally, so let's get rid of them. Rewriting this properly is ... tricky.