### PR TITLE
hidraw: print the list of loaded BPFs, if any

### DIFF
--- a/src/hidraw.rs
+++ b/src/hidraw.rs
@@ -372,6 +372,19 @@ fn preload_bpf_tracer(use_bpf: BpfOption, path: &Path) -> Result<HidBpfSkel> {
         BpfOption::Auto => bpffs.exists(),
     };
 
+    if bpffs.exists() {
+        if let Ok(readdir) = std::fs::read_dir(bpffs) {
+            let bpfs = readdir
+                .flatten()
+                .map(|e| String::from(e.file_name().to_string_lossy()))
+                .collect::<Vec<String>>();
+            Outfile::new().writeln(
+                &Styles::None,
+                &format!("# BPF programs active: {}", bpfs.join(", ")),
+            );
+        }
+    }
+
     if !enable_bpf {
         return Ok(HidBpfSkel::None);
     }


### PR DESCRIPTION
For example:
```
  ##############################################################################
  # Recorded events below in format:
  # E: <seconds>.<microseconds> <length-in-bytes> [bytes ...]
  #
  # BPF programs active: 10-Huion__Inspiroy-2-S_bpf
```