### PR TITLE
Bump hut dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ nix = { version = "0.28.0", features = ["poll"] }
 owo-colors = { version = "4.0.0", features = ["supports-colors"] }
 chrono = "0.4.38"
 hidreport = "0.5.0"
-hut = "0.3.0"
+hut = "0.4.0"
 human-sort = "0.2.2"
 libbpf-rs = "0.23"
 yaml-rust2 = "0.8.1"


### PR DESCRIPTION
Not functionally required but we might as well use the latest.